### PR TITLE
Add bin/run helper script

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o errtrace
+set -o nounset
+set -o pipefail
+
+# Builds and runs kubectl-nearby with the given args (if any)
+
+source "bin/lib/build-utils.sh"
+
+go run \
+  "$(_ldflags)" \
+  $(git ls-files -- '*.go' ':!:*_test.go') \
+  "${@}"


### PR DESCRIPTION
This adds a helper script for local development that wraps `go run` with the relevant options.