### PR TITLE
Fix release script

### DIFF
--- a/bin/lib/build-utils.sh
+++ b/bin/lib/build-utils.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+function _go_files() {
+  find . -type f -name '*.go' -depth 1 -not -name '*_test.go' \
+    | tr '\r\n' ' '
+}
+
 function _ldflags() {
   local version="${1:-development}"
   local package_name="main"

--- a/bin/release
+++ b/bin/release
@@ -55,7 +55,7 @@ for target in darwin/amd64 linux/amd64; do
   release_directory="${base_directory}/targets/${os}/${platform}"
   mkdir -p "${release_directory}"
   binary_file_path="${release_directory}/${binary_name}"
-  GOOS="${os}" GOARCH="${platform}" go build -o "${binary_file_path}" "$(_ldflags "${version}")" $(git ls-files -- '*.go' ':!:*_test.go')
+  GOOS="${os}" GOARCH="${platform}" go build -o "${binary_file_path}" "$(_ldflags "${version}")" $(_go_files)
   echo "== Created ${binary_file_path}"
   compressed_filename="${binary_name}-${version}-${os}-${platform}.tar.gz"
   # COPYFILE_DISABLE prevents a MacOS metadata file from being included in the tar

--- a/bin/run
+++ b/bin/run
@@ -9,11 +9,6 @@ set -o pipefail
 
 source "bin/lib/build-utils.sh"
 
-function _go_files() {
-  find . -type f -name '*.go' -depth 1 -not -name '*_test.go' \
-    | tr '\r\n' ' '
-}
-
 go run \
   "$(_ldflags)" \
   $(_go_files) \


### PR DESCRIPTION
The `go build` step was failing with:

```
named files must all be in one directory; have ./ and pkg/nodes/
```

This PR fixes the error by excluding files from the `nodes` and `output` packages (introduced in #14).