### PR TITLE
Use go build . for releases

### DIFF
--- a/bin/lib/build-utils.sh
+++ b/bin/lib/build-utils.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-function _go_files() {
-  find . -type f -name '*.go' -depth 1 -not -name '*_test.go' \
-    | tr '\r\n' ' '
-}
-
 function _ldflags() {
   local version="${1:-development}"
   local package_name="main"

--- a/bin/release
+++ b/bin/release
@@ -55,7 +55,7 @@ for target in darwin/amd64 darwin/arm64 linux/amd64 linux/arm64; do
   release_directory="${base_directory}/targets/${os}/${platform}"
   mkdir -p "${release_directory}"
   binary_file_path="${release_directory}/${binary_name}"
-  GOOS="${os}" GOARCH="${platform}" go build -o "${binary_file_path}" "$(_ldflags "${version}")" $(_go_files)
+  GOOS="${os}" GOARCH="${platform}" go build -o "${binary_file_path}" "$(_ldflags "${version}")" .
   echo "== Created ${binary_file_path}"
   compressed_filename="${binary_name}-${version}-${os}-${platform}.tar.gz"
   # COPYFILE_DISABLE prevents a MacOS metadata file from being included in the tar


### PR DESCRIPTION
This removes the need for the `_go_files` function.